### PR TITLE
build warning and test fixes

### DIFF
--- a/lmdb/example_test.go
+++ b/lmdb/example_test.go
@@ -339,6 +339,7 @@ func ExampleEnv() {
 	defer env.Close()
 
 	var dbi lmdb.DBI
+	_ = dbi
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
 		// open a database, creating it if necessary.  the database is stored
 		// outside the transaction via closure and can be use after the
@@ -666,6 +667,7 @@ func ExampleTxn_OpenDBI() {
 	// DBI handles can be saved after their opening transaction has committed
 	// and may be reused as long as the environment remains open.
 	var dbi lmdb.DBI
+	_ = dbi
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
 		dbi, err = txn.OpenDBI("dbfound", 0)
 		return err
@@ -680,6 +682,7 @@ func ExampleTxn_OpenDBI() {
 // data written by Txn./Cursor.Put().
 func ExampleTxn_OpenDBI_create() {
 	var dbi lmdb.DBI
+	_ = dbi
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
 		dbi, err = txn.OpenDBI("dbnew", lmdb.Create)
 		return err
@@ -694,6 +697,7 @@ func ExampleTxn_OpenDBI_create() {
 // IsNotFound() will test an error for this condition.
 func ExampleTxn_OpenDBI_notFound() {
 	var dbi lmdb.DBI
+	_ = dbi
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
 		dbi, err = txn.OpenDBI("dbnotfound", 0)
 		return err
@@ -707,6 +711,7 @@ func ExampleTxn_OpenDBI_notFound() {
 // case then the function IsError() can test an error for this condition.
 func ExampleTxn_OpenDBI_dBsFull() {
 	var dbi lmdb.DBI
+	_ = dbi
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
 		dbi, err = txn.OpenDBI("dbnotexist", 0)
 		return err
@@ -725,6 +730,7 @@ func ExampleTxn_OpenRoot() {
 	if err != nil {
 		panic(err)
 	}
+	_ = dbi
 }
 
 // Txn.OpenRoot may also be called without flags inside View transactions
@@ -768,6 +774,7 @@ func ExampleTxn_Get() {
 	var point struct{ X, Y int }
 	var str string
 	var p1, p2 []byte
+	_, _, _ = str, p1, p2
 
 	// extract data from an example environment/database.  it is critical for application
 	// code to handle errors  but that is omitted here to save space.

--- a/lmdb/mdb.c
+++ b/lmdb/mdb.c
@@ -6726,7 +6726,8 @@ more:
 						offset *= 4; /* space for 4 more */
 						break;
 					}
-					/* FALLTHRU: Big enough MDB_DUPFIXED sub-page */
+					/* FALLTHRU */
+					/* Big enough MDB_DUPFIXED sub-page */
 				case MDB_CURRENT:
 					fp->mp_flags |= P_DIRTY;
 					COPY_PGNO(fp->mp_pgno, mp->mp_pgno);


### PR DESCRIPTION
Some small fixes:

* mask test variables to suppress Go compiler warnings. Currently, we see this:
```
$ go test
# github.com/bmatsuo/lmdb-go/lmdb_test
./example_test.go:769:6: str declared but not used
./example_test.go:770:10: p2 declared but not used
./example_test.go:720:6: dbi declared but not used
./example_test.go:709:6: dbi declared but not used
./example_test.go:696:6: dbi declared but not used
./example_test.go:682:6: dbi declared but not used
./example_test.go:668:6: dbi declared but not used
./example_test.go:341:6: dbi declared but not used
vet: typecheck failures
FAIL	github.com/bmatsuo/lmdb-go/lmdb [build failed]
```
* reformat FALLTHRU statement in C code to match compiler expectations. Currently, we see this:
```
# github.com/bmatsuo/lmdb-go/lmdb
mdb.c: In function ‘mdb_cursor_put’:
mdb.c:6725:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
      if (SIZELEFT(fp) < offset) {
         ^
mdb.c:6731:5: note: here
     case MDB_CURRENT:
     ^~~~
```

This fix would allow to revert 5b328d5b.